### PR TITLE
Fixing Timer1 setup for attiny85

### DIFF
--- a/MANCHESTER.cpp
+++ b/MANCHESTER.cpp
@@ -161,7 +161,7 @@ http://www.atmel.com/dyn/resources/prod_documents/doc2586.pdf
   TCCR1 = _BV(CTC1) | _BV(CS13); //counts every 16 usec with 8Mhz clock
   OCR1C = 4; // Clear TCNT1 every 5 counts (0->4)
   OCR1A = 0; // Trigger interrupt when TCNT1 is reset to 0
-  TIMSK = _BV(OCIE1A); // Turn on interrupt
+  TIMSK |= _BV(OCIE1A); // Turn on interrupt
   TCNT1 = 0; // Set counter to 0
 #elif defined(__AVR_ATmega32U4__)
 /*


### PR DESCRIPTION
In CTC mode on attinyx5, the Counter register is reset on match with OCR1C, not OCR1A.

As a result, the existing code counted 256 time too slow, b/c by default
OCR1C is set to 0xFF, so the count would continue until it overflows.

In other words, we wanted: 1 / (8000000 / 128 / 5) = 80us
But what we got was: 1 / (8000000 / 128 / 256) = 4ms

This fix addresses the problem and ensures that the ISR is called every 80us.

Tested on attiny85.
