### PR TITLE
Fix ATtiny processor macro regression

### DIFF
--- a/Manchester.cpp
+++ b/Manchester.cpp
@@ -286,7 +286,7 @@ void MANRX_SetupReceive(uint8_t speedFactor)
    timer0_attachInterrupt(timer0_ISR);
    timer0_write(ESP.getCycleCount() + ESPtimer); //80Mhz -> 128us
    interrupts();
-  #elif defined( __AVR_ATtinyX5__ )
+  #elif defined( __AVR_ATtiny25__ ) || defined( __AVR_ATtiny45__ ) || defined( __AVR_ATtiny85__ )
 
     /*
     Timer 1 is used with a ATtiny85. 


### PR DESCRIPTION
`__AVR_ATtinyX5__` is a nonstandard macro that may not be defined in all
hardware cores(i.e. [damellis/attiny](https://github.com/damellis/attiny)). This issue was fixed in
https://github.com/mchr3k/arduino-libs-manchester/commit/23880ca2556c4293e018cf272accb433753e8374
but partially regressed in
https://github.com/mchr3k/arduino-libs-manchester/commit/18d6cb83f1d07e32064cc99652a7fd60e00fa59a.

Fixes https://github.com/mchr3k/arduino-libs-manchester/issues/32