### PR TITLE
fix race condition for attiny85

### DIFF
--- a/Manchester.cpp
+++ b/Manchester.cpp
@@ -28,11 +28,11 @@ The data rate is then 600 bits/s.
 
 static int8_t RxPin = 255;
 
-static int16_t rx_sample = 0;
-static int16_t rx_last_sample = 0;
-static uint8_t rx_count = 0;
-static uint8_t rx_sync_count = 0;
-static uint8_t rx_mode = RX_MODE_IDLE;
+volatile static int16_t rx_sample = 0;
+volatile static int16_t rx_last_sample = 0;
+volatile static uint8_t rx_count = 0;
+volatile static uint8_t rx_sync_count = 0;
+volatile static uint8_t rx_mode = RX_MODE_IDLE;
 
 static uint16_t rx_manBits = 0; //the received manchester 32 bits
 static uint8_t rx_numMB = 0; //the number of received manchester bits


### PR DESCRIPTION
I've been trying to get an ATTiny85 receiving Manchester-encoded data from another ATTiny85 transmitting Manchester-encoded data. I had an Arduino Pro Mini with an identical receiver/code to confirm the transmitter was indeed transmitting.

From the _very limited_ testing I've done, there appears to be a race condition (or something...) preventing [`rx_mode` changing to `RX_MODE_MSG`](https://github.com/mchr3k/arduino-libs-manchester/blob/master/Manchester.cpp#L630-L634).

On a hunch, I set each of the relevant variables to volatile, which now seems to make it work (ie. `man.receiveComplete()` now returns true).

Fixes #55 